### PR TITLE
Wildfly EclipseLink persistance.xml fix

### DIFF
--- a/eclipselink/src/main/java/org/jipijapa/eclipselink/EclipseLinkPersistenceProviderAdaptor.java
+++ b/eclipselink/src/main/java/org/jipijapa/eclipselink/EclipseLinkPersistenceProviderAdaptor.java
@@ -69,7 +69,7 @@ public class EclipseLinkPersistenceProviderAdaptor implements
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
     public void addProviderProperties(Map properties, PersistenceUnitMetadata pu) {
-        if (!properties.containsKey(ECLIPSELINK_TARGET_SERVER) && !pu.getProperties().containsKey(ECLIPSELINK_TARGET_SERVER)) {
+        if (!pu.getProperties().containsKey(ECLIPSELINK_TARGET_SERVER)) {
             properties.put(ECLIPSELINK_TARGET_SERVER, JBossAS7ServerPlatform.class.getName());
             properties.put(ECLIPSELINK_ARCHIVE_FACTORY, JBossArchiveFactoryImpl.class.getName());
             properties.put(ECLIPSELINK_LOGGING_LOGGER, JBossLogger.class.getName());

--- a/eclipselink/src/main/java/org/jipijapa/eclipselink/EclipseLinkPersistenceProviderAdaptor.java
+++ b/eclipselink/src/main/java/org/jipijapa/eclipselink/EclipseLinkPersistenceProviderAdaptor.java
@@ -17,14 +17,14 @@
 
 package org.jipijapa.eclipselink;
 
-import java.util.Map;
-
 import org.jboss.logging.Logger;
 import org.jipijapa.plugin.spi.JtaManager;
 import org.jipijapa.plugin.spi.ManagementAdaptor;
 import org.jipijapa.plugin.spi.PersistenceProviderAdaptor;
 import org.jipijapa.plugin.spi.PersistenceUnitMetadata;
 import org.jipijapa.plugin.spi.Platform;
+
+import java.util.Map;
 
 public class EclipseLinkPersistenceProviderAdaptor implements
         PersistenceProviderAdaptor {
@@ -69,7 +69,7 @@ public class EclipseLinkPersistenceProviderAdaptor implements
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
     public void addProviderProperties(Map properties, PersistenceUnitMetadata pu) {
-        if (!properties.containsKey(ECLIPSELINK_TARGET_SERVER)) {
+        if (!properties.containsKey(ECLIPSELINK_TARGET_SERVER) && !pu.getProperties().containsKey(ECLIPSELINK_TARGET_SERVER)) {
             properties.put(ECLIPSELINK_TARGET_SERVER, JBossAS7ServerPlatform.class.getName());
             properties.put(ECLIPSELINK_ARCHIVE_FACTORY, JBossArchiveFactoryImpl.class.getName());
             properties.put(ECLIPSELINK_LOGGING_LOGGER, JBossLogger.class.getName());


### PR DESCRIPTION
 Fix for evaluating existence of properties both from persistance.xml and system properties, in case of wildfly setup. As of current version setting up properties in persistance.xml does not seem to have any effect in  jipijapa logger facility configuration in case of wildfly setup. 

Example: 

``` xml
 <properties>
            <property name="eclipselink.target-server" value="JBoss"/>
 <properties>
```
